### PR TITLE
Add URL query parameter for documentation url sharing

### DIFF
--- a/app/components/documentation.hbs
+++ b/app/components/documentation.hbs
@@ -1,7 +1,7 @@
 <div class="pure-g">
     <div class="pure-u-1-5">
         <div class='sw-docs-menu'>
-            <MenuItems @docTree={{@docTree}} @level={{0}} @clickHandler={{this.changeDoc}}/>
+            <MenuItems @docTree={{@docTree}} @level={{0}} @clickHandler={{@onDocChange}}/>
         </div>
     </div>
     <div class="pure-u-4-5">

--- a/app/components/documentation.js
+++ b/app/components/documentation.js
@@ -1,13 +1,9 @@
 import Component from '@glimmer/component';
-import { tracked } from '@glimmer/tracking';
-import { action } from '@ember/object';
 import { htmlSafe } from '@ember/template';
 
 export default class DocumentationComponent extends Component {
-  @tracked currentDoc = htmlSafe("<zero-md src='https://raw.githubusercontent.com/mu-semtech/mu-project/master/README.md'></zero-md>");
-
-  @action
-  changeDoc(url){
-    this.currentDoc = htmlSafe("<zero-md src='"+url+"'></zero-md>");
+  get currentDoc() {
+    const url = this.args.currentDocUrl;
+    return htmlSafe(`<zero-md src='${url}'></zero-md>`);
   }
 }

--- a/app/components/menu-items.hbs
+++ b/app/components/menu-items.hbs
@@ -1,10 +1,8 @@
 {{#each @docTree as |leaf|}}
-  {{#if leaf.value}}
-    {{#if leaf.link}}
-      {{this.whitespace}}<button class="tree-button" type="button" {{on "click" (fn @clickHandler leaf.value)}}>{{leaf.name}}</button><br>
-    {{else}}
-      {{this.whitespace}}{{leaf.name}}<br>
-    {{/if}}
+  {{#if leaf.link}}
+    {{this.whitespace}}<button class="tree-button" type="button" {{on "click" (fn @clickHandler leaf.id)}}>{{leaf.name}}</button><br>
+  {{else if leaf.value}}
+    {{this.whitespace}}{{leaf.name}}<br>
     <MenuItems @docTree={{leaf.value}} @level={{this.nextLevel}} @clickHandler={{@clickHandler}}/>
   {{/if}}
 {{/each}}

--- a/app/controllers/docs.js
+++ b/app/controllers/docs.js
@@ -1,6 +1,47 @@
 import Controller from '@ember/controller';
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
 
 export default class DocsController extends Controller {
+  queryParams = ['doc'];
+
+  @tracked doc = 'project-template';
+
+  get currentDocUrl() {
+    return this.docLookup[this.doc] || this.docLookup['project-template'];
+  }
+
+  @action
+  changeDoc(id) {
+    this.doc = id;
+  }
+
+  docLookup = {
+    'project-template': 'https://raw.githubusercontent.com/mu-semtech/mu-project/master/README.md',
+    'identifier': 'https://raw.githubusercontent.com/mu-semtech/mu-identifier/master/README.md',
+    'dispatcher': 'https://raw.githubusercontent.com/mu-semtech/mu-dispatcher/master/README.md',
+    'authorization-new': 'https://raw.githubusercontent.com/mu-semtech/sparql-parser/master/README.md',
+    'authorization-old': 'https://raw.githubusercontent.com/mu-semtech/mu-authorization/master/README.md',
+    'delta-notifier': 'https://raw.githubusercontent.com/mu-semtech/delta-notifier/master/README.md',
+    'javascript-template': 'https://raw.githubusercontent.com/mu-semtech/mu-javascript-template/master/README.md',
+    'ruby-template': 'https://raw.githubusercontent.com/mu-semtech/mu-ruby-template/master/README.md',
+    'python-template': 'https://raw.githubusercontent.com/mu-semtech/mu-python-template/master/README.md',
+    'login-service': 'https://raw.githubusercontent.com/mu-semtech/login-service/master/README.md',
+    'registration-service': 'https://raw.githubusercontent.com/mu-semtech/registration-service/master/README.md',
+    'resources-service': 'https://raw.githubusercontent.com/mu-semtech/mu-cl-resources/master/README.md',
+    'file-service': 'https://raw.githubusercontent.com/mu-semtech/file-service/master/README.md',
+    'migrations-service': 'https://raw.githubusercontent.com/mu-semtech/mu-migrations-service/master/README.md',
+    'search': 'https://raw.githubusercontent.com/mu-semtech/mu-search/master/README.md',
+    'cache': 'https://raw.githubusercontent.com/mu-semtech/mu-cache/master/README.md',
+    'data-table': 'https://raw.githubusercontent.com/mu-semtech/ember-data-table/master/README.md',
+    'login-addon': 'https://raw.githubusercontent.com/mu-semtech/ember-mu-login/master/README.md',
+    'registration-addon': 'https://raw.githubusercontent.com/mu-semtech/ember-mu-registration/master/README.md',
+    'transform-helpers': 'https://raw.githubusercontent.com/mu-semtech/ember-mu-transform-helpers/master/README.md',
+    'mu-cli': 'https://raw.githubusercontent.com/mu-semtech/mu-cli/master/README.md',
+    'homebrew-scripts': 'https://raw.githubusercontent.com/mu-semtech/homebrew-scripts/master/README.md',
+    'openapi-generator': 'https://raw.githubusercontent.com/mu-semtech/cl-resources-openapi-generator/master/README.md',
+  };
+
   docTree = [
     {
       "name": "Documentation",
@@ -10,53 +51,53 @@ export default class DocsController extends Controller {
           "name": "Core",
           "link": false,
           "value": [
-            {"name": "Project template", "value":"https://raw.githubusercontent.com/mu-semtech/mu-project/master/README.md", "link": true},
-            {"name": "Identifier", "value":"https://raw.githubusercontent.com/mu-semtech/mu-identifier/master/README.md", "link": true},
-            {"name": "Dispatcher", "value":"https://raw.githubusercontent.com/mu-semtech/mu-dispatcher/master/README.md", "link": true},
-            {"name": "Authorization (new)", "value":"https://raw.githubusercontent.com/mu-semtech/sparql-parser/master/README.md", "link": true},
-            {"name": "Authorization (old)", "value":"https://raw.githubusercontent.com/mu-semtech/mu-authorization/master/README.md", "link": true},
-            {"name": "Delta notifier", "value":"https://raw.githubusercontent.com/mu-semtech/delta-notifier/master/README.md", "link": true}
+            {"name": "Project template", "id": "project-template", "link": true},
+            {"name": "Identifier", "id": "identifier", "link": true},
+            {"name": "Dispatcher", "id": "dispatcher", "link": true},
+            {"name": "Authorization (new)", "id": "authorization-new", "link": true},
+            {"name": "Authorization (old)", "id": "authorization-old", "link": true},
+            {"name": "Delta notifier", "id": "delta-notifier", "link": true}
           ]
         },
         {
           "name": "Templates",
           "link": false,
           "value": [
-            {"name": "Javascript template", "value":"https://raw.githubusercontent.com/mu-semtech/mu-javascript-template/master/README.md", "link": true},
-            {"name": "Ruby template", "value":"https://raw.githubusercontent.com/mu-semtech/mu-ruby-template/master/README.md", "link": true},
-            {"name": "Python template", "value":"https://raw.githubusercontent.com/mu-semtech/mu-python-template/master/README.md", "link": true},
+            {"name": "Javascript template", "id": "javascript-template", "link": true},
+            {"name": "Ruby template", "id": "ruby-template", "link": true},
+            {"name": "Python template", "id": "python-template", "link": true},
           ]
         },
         {
           "name": "Microservices",
           "link": false,
           "value": [
-            {"name": "Login service", "value":"https://raw.githubusercontent.com/mu-semtech/login-service/master/README.md", "link": true},
-            {"name": "Registration service", "value":"https://raw.githubusercontent.com/mu-semtech/registration-service/master/README.md", "link": true},
-            {"name": "Resources service", "value":"https://raw.githubusercontent.com/mu-semtech/mu-cl-resources/master/README.md", "link": true},
-            {"name": "File service", "value":"https://raw.githubusercontent.com/mu-semtech/file-service/master/README.md", "link": true},
-            {"name": "Migrations service", "value":"https://raw.githubusercontent.com/mu-semtech/mu-migrations-service/master/README.md", "link": true},
-            {"name": "Search", "value":"https://raw.githubusercontent.com/mu-semtech/mu-search/master/README.md", "link": true},
-            {"name": "Cache", "value":"https://raw.githubusercontent.com/mu-semtech/mu-cache/master/README.md", "link": true},
+            {"name": "Login service", "id": "login-service", "link": true},
+            {"name": "Registration service", "id": "registration-service", "link": true},
+            {"name": "Resources service", "id": "resources-service", "link": true},
+            {"name": "File service", "id": "file-service", "link": true},
+            {"name": "Migrations service", "id": "migrations-service", "link": true},
+            {"name": "Search", "id": "search", "link": true},
+            {"name": "Cache", "id": "cache", "link": true},
           ]
         },
         {
           "name": "Ember addons",
           "link": false,
           "value": [
-            {"name": "Data table", "value":"https://raw.githubusercontent.com/mu-semtech/ember-data-table/master/README.md", "link": true},
-            {"name": "Login addon", "value":"https://raw.githubusercontent.com/mu-semtech/ember-mu-login/master/README.md", "link": true},
-            {"name": "Registration addon", "value":"https://raw.githubusercontent.com/mu-semtech/ember-mu-registration/master/README.md", "link": true},
-            {"name": "Transform helpers", "value":"https://raw.githubusercontent.com/mu-semtech/ember-mu-transform-helpers/master/README.md", "link": true},
+            {"name": "Data table", "id": "data-table", "link": true},
+            {"name": "Login addon", "id": "login-addon", "link": true},
+            {"name": "Registration addon", "id": "registration-addon", "link": true},
+            {"name": "Transform helpers", "id": "transform-helpers", "link": true},
           ]
         },
         {
           "name": "Tools",
           "link": false,
           "value": [
-            {"name": "mu-cli", "value":"https://raw.githubusercontent.com/mu-semtech/mu-cli/master/README.md", "link": true},
-            {"name": "Homebrew scripts", "value":"https://raw.githubusercontent.com/mu-semtech/homebrew-scripts/master/README.md", "link": true},
-            {"name": "OpenAPI generator", "value":"https://raw.githubusercontent.com/mu-semtech/cl-resources-openapi-generator/master/README.md", "link": true},
+            {"name": "mu-cli", "id": "mu-cli", "link": true},
+            {"name": "Homebrew scripts", "id": "homebrew-scripts", "link": true},
+            {"name": "OpenAPI generator", "id": "openapi-generator", "link": true},
           ]
         }
       ]}

--- a/app/templates/docs.hbs
+++ b/app/templates/docs.hbs
@@ -1,1 +1,1 @@
-<Documentation @docTree={{this.docTree}}/>
+<Documentation @docTree={{this.docTree}} @currentDocUrl={{this.currentDocUrl}} @onDocChange={{this.changeDoc}}/>


### PR DESCRIPTION
When browsing https://semantic.works/docs , the current tab wasn't saved in the url, thus you couldn't share a specific part of the docs to someone.
Now there is a query parameter which makes it possible to share certain sections of the docs with people ex: https://semantic.works/docs?doc=login-service